### PR TITLE
Enhance label validation

### DIFF
--- a/client/src/app/components/Autocomplete/Autocomplete.tsx
+++ b/client/src/app/components/Autocomplete/Autocomplete.tsx
@@ -125,6 +125,13 @@ export const Autocomplete: React.FC<IAutocompleteProps> = ({
       isExpanded={isDropdownOpen}
       isDisabled={isDisabled}
       isFullWidth
+      status={
+        inputValue && validateNewOption
+          ? !validateNewOption(inputValue)
+            ? "danger"
+            : undefined
+          : undefined
+      }
     >
       {inputGroup}
     </MenuToggle>
@@ -138,13 +145,12 @@ export const Autocomplete: React.FC<IAutocompleteProps> = ({
             isDropdownOpen &&
             (optionsNotSelected.length > 0 ||
               !!noResultsMessage ||
-              !!onCreateNewOption)
+              (!!onCreateNewOption && inputValue.length > 0))
           }
           selected={selections}
           onOpenChange={setIsDropdownOpen}
           toggle={toggle}
           variant="typeahead"
-          maxMenuHeight=""
         >
           <SelectList id="select-create-typeahead-listbox">
             {onCreateNewOption && optionsNotSelected.length === 0 ? (

--- a/client/src/app/components/Autocomplete/useAutocompleteHandlers.ts
+++ b/client/src/app/components/Autocomplete/useAutocompleteHandlers.ts
@@ -83,19 +83,18 @@ export const useAutocompleteHandlers = ({
 
     const updatedSelections = [...filteredSelections, value];
     onChange(updatedSelections);
-
-    handleInputChange("");
-    setIsDropdownOpen(false);
   };
 
   const handleOnCreateNewOption = (value: string) => {
-    if (value && onCreateNewOption) {
+    if (value !== "" && onCreateNewOption) {
       const isValid = validateNewOption ? validateNewOption(value) : true;
       if (isValid) {
-        const newOption = onCreateNewOption(inputValue);
+        const newOption = onCreateNewOption(value);
         handleOnSelect(newOption);
       }
     }
+    handleInputChange("");
+    setIsDropdownOpen(false);
   };
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {

--- a/client/src/app/components/Autocomplete/useAutocompleteHandlers.ts
+++ b/client/src/app/components/Autocomplete/useAutocompleteHandlers.ts
@@ -83,6 +83,9 @@ export const useAutocompleteHandlers = ({
 
     const updatedSelections = [...filteredSelections, value];
     onChange(updatedSelections);
+
+    handleInputChange("");
+    setIsDropdownOpen(false);
   };
 
   const handleOnCreateNewOption = (value: string) => {
@@ -93,8 +96,6 @@ export const useAutocompleteHandlers = ({
         handleOnSelect(newOption);
       }
     }
-    handleInputChange("");
-    setIsDropdownOpen(false);
   };
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {

--- a/client/src/app/components/EditLabelsForm.tsx
+++ b/client/src/app/components/EditLabelsForm.tsx
@@ -129,7 +129,9 @@ export const EditLabelsForm: React.FC<EditLabelsFormProps> = ({
             validateNewOption={(value) =>
               !!value &&
               value.trim().length > 0 &&
-              /^(?!.*\\)(?!\s*\\)(?!\s*=)[^=\\\s][^=\\]*\s*=?\s*[^=\\]+$/.test(value)
+              /^(?!.*\\)(?!\s*\\)(?!\s*=)[^=\\\s][^=\\]*\s*=?\s*[^=\\]+$/.test(
+                value,
+              )
             }
             filterBeforeOnChange={(selections, newOption) => {
               const newOptionKeyValue = splitStringAsKeyValue(

--- a/client/src/app/components/EditLabelsForm.tsx
+++ b/client/src/app/components/EditLabelsForm.tsx
@@ -129,7 +129,7 @@ export const EditLabelsForm: React.FC<EditLabelsFormProps> = ({
             validateNewOption={(value) =>
               !!value &&
               value.trim().length > 0 &&
-              /^[^=][^=]*=?[^=]*$/.test(value)
+              /^(?!.*\\)(?!\s*\\)(?!\s*=)[^=\\\s][^=\\]*\s*=?\s*[^=\\]+$/.test(value)
             }
             filterBeforeOnChange={(selections, newOption) => {
               const newOptionKeyValue = splitStringAsKeyValue(

--- a/crate/build.rs
+++ b/crate/build.rs
@@ -17,7 +17,7 @@ static NPM_CMD: &str = "npm";
 fn main() {
     println!("Build Trustify - build.rs!");
 
-    println!("cargo:rerun-if-changed={UI_DIR_SRC}");
+    println!("cargo:rerun-if-changed={}", UI_DIR_SRC);
 
     build_ui().expect("Error while building UI");
 

--- a/crate/build.rs
+++ b/crate/build.rs
@@ -17,7 +17,7 @@ static NPM_CMD: &str = "npm";
 fn main() {
     println!("Build Trustify - build.rs!");
 
-    println!("cargo:rerun-if-changed={}", UI_DIR_SRC);
+    println!("cargo:rerun-if-changed={UI_DIR_SRC}");
 
     build_ui().expect("Error while building UI");
 


### PR DESCRIPTION
- Autocomplete.tsx
  - Includes a danger status in case the text typed by the user is not valid
  - Does not open if the text typed by the user is empty. that should fix https://issues.redhat.com/browse/TC-2661
- useAutocompleteHandlers.ts
  - Restore changes made, and keep the current code from main branch
- EditLabelsForm.tsx
  - Enhance the regex validation so the character `\` is not allowed and also the texts like `something=` is not allowed just like Openshift. Even if `something=` is not valid, `something` is still valid
- crate/build.rs
  - Restore changes made, and keep the current code from main branch
